### PR TITLE
[Cursor] Simplify footer by removing social media icons

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -40,26 +40,8 @@ export default function RootLayout({
           {/* Footer section */}
           <footer className="bg-black/40 backdrop-blur-md border-t border-white/20 py-8 mt-auto relative z-20">
             <div className="container mx-auto px-4">
-              <div className="flex flex-col md:flex-row justify-between items-center">
-                <div className="mb-4 md:mb-0">
-                  <p className="text-white/80 text-sm">&copy; {new Date().getFullYear()} Crystal Seed Tarot. All rights reserved.</p>
-                </div>
-                <div className="flex space-x-4">
-                  <a href="#" className="text-white/80 hover:text-white transition-colors">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
-                      <path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z"></path>
-                    </svg>
-                    <span className="sr-only">Facebook</span>
-                  </a>
-                  <a href="#" className="text-white/80 hover:text-white transition-colors">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
-                      <rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect>
-                      <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path>
-                      <line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line>
-                    </svg>
-                    <span className="sr-only">Instagram</span>
-                  </a>
-                </div>
+              <div className="flex justify-center items-center">
+                <p className="text-white/80 text-sm">&copy; {new Date().getFullYear()} Crystal Seed Tarot. All rights reserved.</p>
               </div>
             </div>
           </footer>


### PR DESCRIPTION
   ## Changes
   - Removed Facebook and Instagram icons from the footer
   - Simplified the footer layout to only display the copyright text
   - Center-aligned the copyright text for better visual balance
   - Maintained the frosted glass effect and border styling

   ## Testing
   - Verified the footer displays correctly with only the copyright text
   - Confirmed the footer is properly positioned at the bottom of the page
   - Tested on multiple viewport sizes to ensure responsive behavior
   - Checked that the styling remains consistent with the site's design

   ## Notes
   - This change aligns with the client's request to simplify the site's footer
   - No additional dependencies were required for this change