### PR TITLE
[Cursor] Add Accepting the Totality of Your Worth blog with custom date

### DIFF
--- a/lib/contentful.ts
+++ b/lib/contentful.ts
@@ -13,6 +13,7 @@ const client = createClient({
 const CUSTOM_PUBLISH_DATES: Record<string, string> = {
   "better-practices-for-your-practice": "2025-02-23T12:00:00.000Z",
   "when-being-a-good-person-goes-bad": "2023-02-03T12:00:00.000Z",
+  "accepting-the-totality-of-your-worth": "2021-11-11T12:00:00.000Z",
 };
 
 // Function to get publish date (custom if available, otherwise from Contentful)


### PR DESCRIPTION
## Changes
- Added custom publish date (November 11, 2021) for the "Accepting the Totality of Your Worth" blog post
- Integrated third blog post into the custom date mapping system

## Testing
- Verified blog appears on the blog page correctly
- Confirmed November 11, 2021 publish date displays properly
- Verified image loads correctly with default .webp extension
- Tested in development environment on localhost:3004

## Notes
- The blog post uses the existing .webp image already in public/images directory
- No special image handling was needed as it uses the default extension