### PR TITLE
[Cursor] Add Be Nice to Yourself, D@mnit! blog with special character handling

### DIFF
--- a/lib/contentful.ts
+++ b/lib/contentful.ts
@@ -15,6 +15,7 @@ const CUSTOM_PUBLISH_DATES: Record<string, string> = {
   "when-being-a-good-person-goes-bad": "2023-02-03T12:00:00.000Z",
   "accepting-the-totality-of-your-worth": "2021-11-11T12:00:00.000Z",
   "the-irrational-fear-of-starting-over": "2021-06-15T12:00:00.000Z",
+  "be-nice-to-yourself-d-mnit": "2021-02-21T12:00:00.000Z",
 };
 
 // Function to get publish date (custom if available, otherwise from Contentful)

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -70,15 +70,22 @@ export function generateBlogImagePath(title: string): string {
     return "/images/blog-placeholder.jpg";
   }
 
-  // Special case for blog titles with special characters that need exact filename matching
+  // Convert title to slug format for lookup
+  const slug = title
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-");
+
+  // Special case mapping based on slugs for more reliable matching
   const specialCaseImages: Record<string, string> = {
-    "Be Nice to Yourself, D@mnit!": "/images/Blog-Be-Nice-to-Yourself-D@mnit!.webp",
+    "be-nice-to-yourself-dmnit": "/images/Blog-Be-Nice-to-Yourself-D@mnit!.webp",
   };
 
-  // Check if we have a special case exact match for this title
-  if (specialCaseImages[title]) {
-    console.log(`Using special case image path for "${title}": ${specialCaseImages[title]}`);
-    return specialCaseImages[title];
+  // Check if we have a special case for this slug
+  if (specialCaseImages[slug]) {
+    console.log(`Using special case image path for slug "${slug}": ${specialCaseImages[slug]}`);
+    return specialCaseImages[slug];
   }
 
   // Create a mapping of blog slugs to their file extensions
@@ -87,13 +94,6 @@ export function generateBlogImagePath(title: string): string {
     // Add more mappings here as needed
   };
   
-  // Convert title to slug format for lookup
-  const slug = title
-    .toLowerCase()
-    .replace(/[^\w\s-]/g, "")
-    .trim()
-    .replace(/\s+/g, "-");
-    
   // Use the mapped extension if available, otherwise default to webp
   const extension = blogImageExtensions[slug] || "webp";
   

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -70,6 +70,17 @@ export function generateBlogImagePath(title: string): string {
     return "/images/blog-placeholder.jpg";
   }
 
+  // Special case for blog titles with special characters that need exact filename matching
+  const specialCaseImages: Record<string, string> = {
+    "Be Nice to Yourself, D@mnit!": "/images/Blog-Be-Nice-to-Yourself-D@mnit!.webp",
+  };
+
+  // Check if we have a special case exact match for this title
+  if (specialCaseImages[title]) {
+    console.log(`Using special case image path for "${title}": ${specialCaseImages[title]}`);
+    return specialCaseImages[title];
+  }
+
   // Create a mapping of blog slugs to their file extensions
   const blogImageExtensions: Record<string, string> = {
     "when-being-a-good-person-goes-bad": "jpg",


### PR DESCRIPTION
## Changes
- Added custom publish date (February 21, 2021) for "Be Nice to Yourself, D@mnit!" blog post
- Implemented special case handling for image files with special characters (@)
- Created a more robust slug-based mapping system for blog image paths
- Added debug logging to improve troubleshooting

## Testing
- Verified blog appears on the blog page correctly
- Confirmed February 21, 2021 publish date displays properly
- Fixed image path to handle special characters in the filename
- Verified that all blogs display with the correct images
- Tested in development environment on localhost:3007

## Notes
- The update uses a more reliable slug-based approach to handle special characters in filenames
- This approach can be extended for other special character cases in the future