### PR TITLE
Fix event flyer cropping for square images

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -27,6 +27,7 @@ interface Event {
   imageUrl: string;
   linkUrl?: string;
   buttonText?: string;
+  imageAspect?: 'square' | 'landscape';
 }
 
 export default function Events() {
@@ -41,6 +42,7 @@ export default function Events() {
       imageUrl: "/images/Events-Tarot-Foundations-Summer-2026.jpeg",
       linkUrl: "https://www.eventbrite.com/e/the-tarot-path-a-4-week-beginner-to-intermediate-training-tickets-1989265106483?aff=oddtdtcreator",
       buttonText: "Register for Course",
+      imageAspect: "square",
     },
     {
       id: "9",
@@ -179,12 +181,12 @@ export default function Events() {
                 >
                   {/* Event image */}
                   <div className="mb-6">
-                    <div className="relative w-full aspect-video md:aspect-[16/9] overflow-hidden rounded-lg">
+                    <div className="relative w-full overflow-hidden rounded-lg" style={{ aspectRatio: event.imageAspect === 'square' ? '1/1' : '16/9' }}>
                       <Image
                         src={event.imageUrl}
                         alt={event.title}
                         fill
-                        className="object-cover transition-all duration-300 hover:brightness-110"
+                        className={`${event.imageAspect === 'square' ? 'object-contain' : 'object-cover'} transition-all duration-300 hover:brightness-110`}
                         sizes="(max-width: 768px) 100vw, 800px"
                       />
                     </div>


### PR DESCRIPTION
## Summary
- Square event flyer images (like the Tarot Foundations 2048x2048 jpeg) were getting cropped to 16:9, cutting off discount codes and registration info at the bottom
- Added `imageAspect` property to the Event interface so square images render at 1:1 with `object-contain` instead of being force-cropped

## Test plan
- [ ] Verify the Tarot Foundations flyer shows the full image including discount codes at the bottom
- [ ] Verify other events with landscape images still render correctly at 16:9

🤖 Generated with [Claude Code](https://claude.com/claude-code)